### PR TITLE
fix random admin password evaluation when `administrator_password` is specified

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -5,5 +5,5 @@ locals {
     "MemoryOptimized" = "MO"
   }
 
-  administrator_password = coalesce(var.administrator_password, random_password.administrator_password[0].result)
+  administrator_password = coalesce(var.administrator_password, one(random_password.administrator_password[*].result))
 }


### PR DESCRIPTION
Fixes #(issue) .

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

When`administrator_password` is specified;

<img width="1110" alt="Screenshot 2024-07-14 at 19 20 57" src="https://github.com/user-attachments/assets/4ca378d2-cf36-4f39-85ad-d577f5dc5d05">



@claranet/fr-azure-reviewers
