### PR TITLE
fix(GH-10): fix failing refresh-only plan when variable is unavailable

### DIFF
--- a/r-postgresql-flexible.tf
+++ b/r-postgresql-flexible.tf
@@ -105,7 +105,7 @@ moved {
 }
 
 resource "azurerm_postgresql_flexible_server_firewall_rule" "main" {
-  for_each = var.delegated_subnet_id == null ? var.allowed_cidrs : {}
+  for_each = var.allowed_cidrs
 
   name             = each.key
   server_id        = azurerm_postgresql_flexible_server.main.id


### PR DESCRIPTION
Fixes https://github.com/claranet/terraform-azurerm-db-postgresql-flexible/issues/10

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

- create firewall rules when "allowed_cidrs" are provided, not taking into account the (known only after apply) "delegated_subnet_id"

@claranet/fr-azure-reviewers
